### PR TITLE
Increased the maximum number of datapoints to 2^20 = 1048576. (Ticket 7962)

### DIFF
--- a/plugins/com.isti.xmax.psd/plugin.xml
+++ b/plugins/com.isti.xmax.psd/plugin.xml
@@ -12,6 +12,6 @@
 		<parameter id="class" value="TransPSD"/>
 		<parameter id="name" value="TransPSD"/> 
 		<parameter id="description" value="Shows power spectra density for selected channels"/>
-		<parameter id="max_data_length" value="524288"/>   
+		<parameter id="max_data_length" value="1048576"/>   
 	</extension> 
 </plugin> 

--- a/plugins/com.isti.xmax.psd/source/TransPSD.java
+++ b/plugins/com.isti.xmax.psd/source/TransPSD.java
@@ -33,7 +33,7 @@ import com.isti.traceview.data.Response;
 public class TransPSD implements ITransformation {
 	private static final Logger logger = Logger.getLogger(TransPSD.class);
 	private static final boolean verboseDebug = false;
-	public int maxDataLength = 524288;
+	public int maxDataLength = 1048576;
 	private int effectiveLength = 0;
 
 	public void transform(List<PlotDataProvider> input, TimeInterval ti, IFilter filter, Object configuration, JFrame parentFrame) {


### PR DESCRIPTION
Increased the maximum number of datapoints to 2^20 = 1048576.  This allows for a maximum of 7.282 hours of BH data, and a maximum of 12.136 days of LH data. (Ticket 7962)