### PR TITLE
Ensure that separator is added to path for response getter

### DIFF
--- a/src/main/java/com/isti/traceview/data/DataModule.java
+++ b/src/main/java/com/isti/traceview/data/DataModule.java
@@ -723,7 +723,7 @@ public class DataModule extends Observable {
     }
 
     String respFileName = "RESP." + network + "." + station + "." + location + "." + channel;
-    File file = new File(dirname + respFileName);
+    File file = new File(dirname + File.separator + respFileName);
     if (file.exists()) {
       whereToAdd.add(file.getAbsolutePath());
       return;


### PR DESCRIPTION
Valid settings for config.xml that run with the last official release on server for response directories don't seem to work for the test build. Specifically, the response directory appears to need a trailing separator in the file in order to work.

This should fix this issue.