### PR TITLE
Fix issue causing reload data option to break GUI

### DIFF
--- a/src/main/java/com/isti/traceview/data/DataModule.java
+++ b/src/main/java/com/isti/traceview/data/DataModule.java
@@ -124,9 +124,6 @@ public class DataModule extends Observable {
     windowSize = 0;
     from = 0;
     to = 0;
-    channels.clear();
-    dataSources.clear();
-    stations.clear();
   }
 
   /**

--- a/src/main/java/com/isti/xmax/gui/XMAXframe.java
+++ b/src/main/java/com/isti/xmax/gui/XMAXframe.java
@@ -3259,10 +3259,11 @@ public class XMAXframe extends JFrame implements MouseInputListener, ActionListe
 				try {
 					graphPanel.setChannelShowSet(dm.getNextChannelSet());
 				} catch (TraceViewException ex) {
-					JOptionPane.showMessageDialog(XMAX.getFrame(), "This is the last set", "Information",
+					JOptionPane.showMessageDialog(XMAX.getFrame(), ex.getMessage(), "Information",
 							JOptionPane.INFORMATION_MESSAGE);
 					getGraphPanel().forceRepaint();
 				}
+
 				statusBar.setChannelCountMessage(dm.getChannelSetStartIndex() + 1, dm.getChannelSetEndIndex(),
 						dm.getAllChannels().size());
 			} catch (TraceViewException e1) {


### PR DESCRIPTION
Turns out that deleting all the data in the backend causes the frontend to screw up. Who knew?