### PR TITLE
Use parent-scoped max data point value, fix error with limits

### DIFF
--- a/src/main/java/com/isti/traceview/transformations/correlation/TransCorrelation.java
+++ b/src/main/java/com/isti/traceview/transformations/correlation/TransCorrelation.java
@@ -27,7 +27,6 @@ public class TransCorrelation implements ITransformation {
 
 	public static final String NAME = "Correlation";
 
-	private static final int maxDataLength = 2^30;
 	private double sampleRate = 0;
 
 	@Override

--- a/src/main/java/com/isti/traceview/transformations/ppm/TransPPM.java
+++ b/src/main/java/com/isti/traceview/transformations/ppm/TransPPM.java
@@ -26,7 +26,6 @@ public class TransPPM implements ITransformation {
 
 	public static final String NAME = "Particle motion";
 
-	private static final int maxDataLength = 2^30;
 
 	@Override
 	public void transform(List<PlotDataProvider> input, TimeInterval ti, IFilter filter, Object configuration,


### PR DESCRIPTION
No point in duplicating the variable in these child classes when it retains the same value anyway