### PR TITLE
Use sign of N,E data to get proper quadrant for azimuth calculation

### DIFF
--- a/src/main/java/com/isti/traceview/transformations/ppm/ViewPPM.java
+++ b/src/main/java/com/isti/traceview/transformations/ppm/ViewPPM.java
@@ -39,22 +39,22 @@ class ViewPPM extends JDialog implements PropertyChangeListener {
 
 		super(owner, "Particle Motion", true);
 
-		altAngle = estimatedBackAzimuth;
+
 
 		Object[] options = { "Close", "Print", "Enter Angle", "+1", "+5", "+30", "-1", "-5", "-30" };
-		// Create the JOptionPane.
-		optionPane = new JOptionPane(createChartPanel(dataset, ti, annotation, filter),
-				JOptionPane.PLAIN_MESSAGE, JOptionPane.CLOSED_OPTION, null, options, options[0]);
+		// Create the JOptionPane. Have to instantiate textTitle w/ default angle here
+		// which will be set to the value calculated by the back-azimuth estimation
+		optionPane = new JOptionPane(
+				createChartPanel(dataset, ti, annotation, filter,  estimatedBackAzimuth),
+				JOptionPane.PLAIN_MESSAGE, JOptionPane.CLOSED_OPTION,  null, options, options[0]);
 
-		// add back azimuth estimation, include ruler
-		double bAzimuth = estimatedBackAzimuth;
-		renderer.setRulerAngle(bAzimuth);
-		double bAzimuthAlt = 180 + estimatedBackAzimuth;
+		// make sure that altAngle changes along with starting value -- 180 out from gotten azimuth
+		altAngle = estimatedBackAzimuth + 180;
 
 
 		TextTitle subTitle =
-				new TextTitle("Back Azimuth Est.: " + bAzimuth + "\u00b0/" +
-						bAzimuthAlt + "\u00b0", ret.getFont());
+				new TextTitle("Back Azimuth Est.: " + estimatedBackAzimuth + "\u00b0/" +
+						altAngle + "\u00b0", ret.getFont());
 		cp.getChart().addSubtitle(1, subTitle);
 
 		// Make this dialog display it.
@@ -158,7 +158,7 @@ class ViewPPM extends JDialog implements PropertyChangeListener {
 	}
 	
 	private static JPanel createChartPanel(XYDataset dataset, TimeInterval ti,
-			String annotation, IFilter filter) {
+			String annotation, IFilter filter, double bAzimuth) {
 		ret = new JPanel();
 		BoxLayout retLayout = new BoxLayout(ret, javax.swing.BoxLayout.Y_AXIS);
 		ret.setLayout(retLayout);
@@ -178,11 +178,12 @@ class ViewPPM extends JDialog implements PropertyChangeListener {
 		chart.setTitle(title);
 
 
-		TextTitle subTitle = new TextTitle("Ruler Angle: 0\u00b0/180\u00b0", ret.getFont());
-		chart.addSubtitle(0, subTitle);
 		PolarPlot plot = (PolarPlot) chart.getPlot();
 		plot.setRenderer(renderer);
-		renderer.setRulerAngle(0.);
+		renderer.setRulerAngle(bAzimuth);
+		TextTitle subTitle = new TextTitle("Angle: " + renderer.getRulerAngle() +
+				"\u00b0/" + (bAzimuth + 180) + "\u00b0", ret.getFont());
+		chart.addSubtitle(0, subTitle);
 		plot.addCornerTextItem(annotation);
 		cp = new TraceViewChartPanel(chart, true);
 		ret.add(cp);

--- a/src/main/java/com/isti/traceview/transformations/ppm/ViewPPM.java
+++ b/src/main/java/com/isti/traceview/transformations/ppm/ViewPPM.java
@@ -48,11 +48,13 @@ class ViewPPM extends JDialog implements PropertyChangeListener {
 
 		// add back azimuth estimation, include ruler
 		double bAzimuth = estimatedBackAzimuth;
-		while (bAzimuth >= 180) {
-			bAzimuth = bAzimuth-180;
-		}
 		renderer.setRulerAngle(bAzimuth);
-		TextTitle subTitle = new TextTitle("Back Azimuth Est.: " + bAzimuth + "\u00b0", ret.getFont());
+		double bAzimuthAlt = 180 + estimatedBackAzimuth;
+
+
+		TextTitle subTitle =
+				new TextTitle("Back Azimuth Est.: " + bAzimuth + "\u00b0/" +
+						bAzimuthAlt + "\u00b0", ret.getFont());
 		cp.getChart().addSubtitle(1, subTitle);
 
 		// Make this dialog display it.

--- a/src/test/java/com/isti/traceview/transformations/ppm/TransPPMTest.java
+++ b/src/test/java/com/isti/traceview/transformations/ppm/TransPPMTest.java
@@ -47,14 +47,33 @@ public class TransPPMTest {
 
     TransPPM ppm = new TransPPM();
     int[][] data = ppm.createDataset(pdpList, null, ti);
-    double bAzimuth = ppm.estimateBackAzimuth(data[0], data[1]);
-
-    while (bAzimuth >= 180) {
-      bAzimuth = bAzimuth-180;
-    }
+    double bAzimuth = TransPPM.estimateBackAzimuth(data[0], data[1]);
 
     assertEquals(73.1489, bAzimuth, 1E-3);
 
+  }
+
+  @Test
+  public void testBackAzimCorrectQuadrant() throws XMAXException {
+    DataModule dm = TraceView.getDataModule();
+
+    List<PlotDataProvider> pdpList = dm.getAllChannels();
+
+    String startTimeString = "2019.108.14:51Z";
+    String endTimeString = "2019.108.14:52Z";
+    DateTimeFormatter dtf = DateTimeFormatter.ofPattern("yyyy.DDD.HH:mmX").withZone(ZoneOffset.UTC);
+    long startTime = ZonedDateTime.parse(startTimeString, dtf).toInstant().toEpochMilli();
+    long endTime = ZonedDateTime.parse(endTimeString, dtf).toInstant().toEpochMilli();
+    TimeInterval ti = new TimeInterval(startTime, endTime);
+
+    TransPPM ppm = new TransPPM();
+    int[][] data = ppm.createDataset(pdpList, null, ti);
+    for (int i = 0; i < data[0].length; ++i) {
+      data[0][i] *= -1.;
+    }
+    double bAzimuth = TransPPM.estimateBackAzimuth(data[0], data[1]);
+
+    assertEquals(180 - 73.1489, bAzimuth, 1E-3);
   }
 
 }


### PR DESCRIPTION
Requires taking the sign of the data.
Because the angle calculations are agnostic about being +/-360, we don't need the vertical data for orientation to find quadrant; it is in either 1 and 3 or 2 and 4.