### PR TITLE
Ensure date->azimuth map instantiated even if empty

### DIFF
--- a/src/main/java/com/isti/traceview/data/Response.java
+++ b/src/main/java/com/isti/traceview/data/Response.java
@@ -65,6 +65,7 @@ public class Response {
     this.channel = channel;
     this.content = content;
     this.fileName = fileName;
+    this.azimuthMap = new HashMap<>();
   }
 
   /**


### PR DESCRIPTION
This was causing issues with rotation for data using standard RESP files, since they didn't necessarily include azimuth data so the map for azimuth values per epoch was not being instantiated.