### PR TITLE
Cached rotation calculation result for speed improvement

### DIFF
--- a/src/main/java/com/asl/traceview/transformations/coherence/TransCoherence.java
+++ b/src/main/java/com/asl/traceview/transformations/coherence/TransCoherence.java
@@ -101,10 +101,12 @@ public class TransCoherence implements ITransformation{
 		PlotDataProvider channel = null;
 		int currentTraceNum = 0; 
 		int numsegs = 1;
+
+
 		while (li.hasNext()) {
 				channel = li.next();
-				List<Segment> segments; 
-	
+				List<Segment> segments;
+
 				if(channel.getRotation() != null && channel.isRotated()) {
 					segments = channel.getRawData(channel.getRotation(), ti); //if data is rotated then calculate the coherence on the rotated data.
 				} else {

--- a/src/main/java/com/isti/traceview/data/RawDataProvider.java
+++ b/src/main/java/com/isti/traceview/data/RawDataProvider.java
@@ -167,7 +167,7 @@ public class RawDataProvider extends Channel {
   }
 
   /**
-   * Get rotated raw data for a given time interval
+   * Get rotated data for a given time interval
    *
    * @param rotation to process data
    * @return rotated raw data

--- a/src/main/java/com/isti/traceview/gui/ChannelView.java
+++ b/src/main/java/com/isti/traceview/gui/ChannelView.java
@@ -610,8 +610,9 @@ public class ChannelView extends JPanel implements Comparable<Object>, Observer 
 			IScaleModeState scaleMode = graphPanel.getScaleMode();
 			IMeanState meanState = graphPanel.getMeanState();
 			IOffsetState offsetState = graphPanel.getOffsetState();
-			scaleMode.init(graphs, (graphPanel.getOverlayState() == true) || (graphPanel.getSelectState() == true) ? graphPanel
-					.getCurrentChannelShowSet() : graphPanel.getChannelShowSet(), graphPanel.getTimeRange(), meanState, height);
+			scaleMode.init(graphs, graphPanel.getOverlayState() || graphPanel.getSelectState() ?
+					graphPanel.getCurrentChannelShowSet() : graphPanel.getChannelShowSet(),
+					graphPanel.getTimeRange(), meanState, height);
 			
 			//lg.debug("scaleMode Initialized:" + scaleMode.getStateName() + scaleMode.getMaxValue() + scaleMode.getMinValue());
 			if (scaleMode.getMinValue() != Double.POSITIVE_INFINITY && scaleMode.getMaxValue() != Double.NEGATIVE_INFINITY) {
@@ -802,8 +803,9 @@ public class ChannelView extends JPanel implements Comparable<Object>, Observer 
 			mousePressY = e.getY();
 			graphPanel.getScaleMode().init(
 					graphs,
-					(graphPanel.getOverlayState() == true) || (graphPanel.getSelectState() == true) ? graphPanel.getCurrentChannelShowSet()
-							: graphPanel.getChannelShowSet(), graphPanel.getTimeRange(), graphPanel.getMeanState(), getHeight());
+					graphPanel.getOverlayState() || graphPanel.getSelectState() ?
+							graphPanel.getCurrentChannelShowSet() : graphPanel.getChannelShowSet(),
+					graphPanel.getTimeRange(), graphPanel.getMeanState(), getHeight());
 			// one-button mouse Mac OSX behaviour emulation
 			if (e.getButton() == MouseEvent.BUTTON1) {
 				if (e.isShiftDown()) {
@@ -821,7 +823,7 @@ public class ChannelView extends JPanel implements Comparable<Object>, Observer 
 
 		public void mouseReleased(MouseEvent e) {
 			if (button != MouseEvent.NOBUTTON && ((mousePressX != e.getX()) || (mousePressY != e.getY()))) {
-				if (button == MouseEvent.BUTTON3 || (button == MouseEvent.BUTTON1 && e.isControlDown() == true)) {
+				if (button == MouseEvent.BUTTON3 || (button == MouseEvent.BUTTON1 && e.isControlDown())) {
 					if (mouseAdapter != null) {
 						mouseAdapter.mouseReleasedButton3(e.getX(), e.getY(), cv);
 					}

--- a/src/main/java/com/isti/traceview/transformations/correlation/TransCorrelation.java
+++ b/src/main/java/com/isti/traceview/transformations/correlation/TransCorrelation.java
@@ -81,7 +81,8 @@ public class TransCorrelation implements ITransformation {
 			throws XMAXException {
 		List<double[]> ret = new ArrayList<>();
 		PlotDataProvider channel1 = input.get(0);
-		List<Segment> segments1; 
+		List<Segment> segments1;
+		// TODO: strip out shared process, run as threaded operation, collect output in a list
 		if(channel1.getRotation() != null)
 			segments1 = channel1.getRawData(ti);
 		else {


### PR DESCRIPTION
This removes redundancy in calculation of rotated data for the given traces. This way if 00.LH1, 00.LH2, and 00.LH3 are all included in some processing (like PSD plotting), the rotation is only done once per trace -- the process for rotating one trace involved calculating the rotated data for the other two as well.