### PR TITLE
Enable runtime load/unload, allow null data on startup

### DIFF
--- a/src/main/java/com/isti/xmax/XMAX.java
+++ b/src/main/java/com/isti/xmax/XMAX.java
@@ -180,27 +180,21 @@ public class XMAX extends TraceView {
 					transformations = reflect.getSubTypesOf(ITransformation.class);
 
 					setDataModule(XMAXDataModule.getInstance());
-
 					getDataModule().loadData();
 
-					if (getDataModule().getAllChannels().size() > 0) {
-						setFrame(XMAXframe.getInstance());
-						if (XMAXconfiguration.getInstance().getTimeInterval() != null) {
-							getFrame().setShouldManageTimeRange(false);
-							getFrame().setTimeRange(XMAXconfiguration.getInstance().getTimeInterval());
-						}
-						try {
-							// Wait while frame will be created to correct repaint
-							Thread.sleep(200);
-						} catch (InterruptedException e) {
-							logger.error("InterruptedException:", e);
-						}
-						getFrame().setVisible(true);
-						getFrame().setShouldManageTimeRange(true);
-					} else {
-						JOptionPane.showMessageDialog(null, "No data found at path " + XMAXconfiguration.getInstance().getDataPath(), "Alert",
-								JOptionPane.WARNING_MESSAGE);
+					setFrame(XMAXframe.getInstance());
+					if (XMAXconfiguration.getInstance().getTimeInterval() != null) {
+						getFrame().setShouldManageTimeRange(false);
+						getFrame().setTimeRange(XMAXconfiguration.getInstance().getTimeInterval());
 					}
+					try {
+						// Wait while frame will be created to correct repaint
+						Thread.sleep(200);
+					} catch (InterruptedException e) {
+						logger.error("InterruptedException:", e);
+					}
+					getFrame().setVisible(true);
+					getFrame().setShouldManageTimeRange(true);
 				}
 			}
 		} catch (Exception e) {


### PR DESCRIPTION
Well, this was at least a simpler procedure than I expected at the outset.
Replaces the "deselect all" button with one to remove selected data from the program, and an additional button to support loading in new data from multiple files at a time.

The program can run without data paths being specified in configuration or command line now, though those will still function, and the data path specified by the configuration/cmd will be where the program defaults for loading in additional data.