### PR TITLE
Fix crosshair scale GUI issue, try to stabilize PSD calculation further

### DIFF
--- a/src/main/java/com/isti/traceview/gui/ScaleModeXhair.java
+++ b/src/main/java/com/isti/traceview/gui/ScaleModeXhair.java
@@ -44,6 +44,17 @@ public class ScaleModeXhair extends ScaleModeAbstract implements IScaleModeState
 		this.height = height;
 	}
 
+	// override super method in order to prevent range argument exception if max is somehow < min
+	// since this is entirely user-specified scaling based on GUI, this is clearly preferable
+	public double getMaxValue() {
+		return Math.max(super.getMaxValue(), super.getMinValue());
+	}
+
+	// same as above, prevents issue where assigned min value is somehow > max
+	public double getMinValue() {
+		return Math.min(super.getMaxValue(), super.getMinValue());
+	}
+
 	public String getStateName() {
 		return "XHAIR";
 	}

--- a/src/main/java/com/isti/traceview/transformations/psd/TransPSD.java
+++ b/src/main/java/com/isti/traceview/transformations/psd/TransPSD.java
@@ -119,10 +119,18 @@ public class TransPSD implements ITransformation {
 
 	private class XYSeriesComparator implements Comparator<XYSeries> {
 
-
 		@Override
 		public int compare(XYSeries o1, XYSeries o2) {
-			return o1.getKey().compareTo(o2.getKey());
+			// These should always be strings in our usage
+			// and since this is a private method anyway this is overly-defensive programming
+			// we COULD do o1.getKey().compareTo(o2.getKey)) but that would cause a warning to show up
+			// and I don't like compiler warnings and neither should you, so we'll do this
+			// and since they're already strings, the toString() method just ensures type-safety without
+			// having to do any weird stuff with casts
+			String key1 = o1.getKey().toString();
+			String key2 = o2.getKey().toString();
+			// anyway since strings are nicely comparable, we'll just call compareTo with those now
+			return key1.compareTo(key2);
 		}
 	}
 

--- a/src/main/java/com/isti/traceview/transformations/psd/TransPSD.java
+++ b/src/main/java/com/isti/traceview/transformations/psd/TransPSD.java
@@ -98,7 +98,7 @@ public class TransPSD implements ITransformation {
 			}
 		});
 
-		Collections.sort(dataset, new XYSeriesComparator());
+		dataset.sort(new XYSeriesComparator());
 
 		long endl = System.nanoTime() - startl;
 		double duration = endl * Math.pow(10, -9);

--- a/src/main/java/com/isti/traceview/transformations/psd/ViewPSD.java
+++ b/src/main/java/com/isti/traceview/transformations/psd/ViewPSD.java
@@ -423,7 +423,7 @@ class ViewPSD extends JDialog implements PropertyChangeListener,
     // unfilteredcollection is a finalized copy of ret to use in the following lambda
     XYSeriesCollection unfilteredCollection = ret;
 
-    ds.parallelStream().forEachOrdered(unfilteredCollection::addSeries);
+    ds.forEach(unfilteredCollection::addSeries);
     ret = filterData(unfilteredCollection);
 
     XYSeries lowNoiseModelSeries = new XYSeries("NLNM");


### PR DESCRIPTION
Sources of issues are not 100% certain but another thread-unsafe parallelization has been undone (it wasn't a particularly computationally-intensive procedure).

Crosshair scale now forces min and max values to be such that min is always <= max. This was causing a GUI error. It is not clear what makes it different from auto scale.