### PR TITLE
PSD calculations no longer attempt to parallelize resp parsing

### DIFF
--- a/src/main/java/com/isti/traceview/data/Response.java
+++ b/src/main/java/com/isti/traceview/data/Response.java
@@ -166,7 +166,7 @@ public class Response {
    * @throws TraceViewException if thrown in {@link
    * com.isti.traceview.processing.RunEvalResp#generateResponse(double, double, int, Date, String)}
    */
-  public Cmplx[] getResp(Date date, double minFreqValue, double maxFreqValue,
+  public synchronized Cmplx[] getResp(Date date, double minFreqValue, double maxFreqValue,
       int len) throws TraceViewException {
     RunEvalResp evalResp = new RunEvalResp(false, verboseDebug);
 


### PR DESCRIPTION
Resp calculation is done before PSD processing is run. EvalResp does multiple operations that are NOT thread-safe and as a result PSD calculation was frequently hanging or failing.