### PR TITLE
Fix PSD duration display bug, replace debugging print statements

### DIFF
--- a/src/main/java/com/isti/traceview/data/DataModule.java
+++ b/src/main/java/com/isti/traceview/data/DataModule.java
@@ -877,7 +877,7 @@ public class DataModule extends Observable {
         File f = new File(respFile);
         resp = Response.getResponse(f);
         if (resp != null) {
-          System.out.println("Response loaded from file: " + respFile);
+          logger.info("Response loaded from file: " + respFile);
           return resp;
         }
       }

--- a/src/main/java/com/isti/traceview/data/SourceSocketFDSN.java
+++ b/src/main/java/com/isti/traceview/data/SourceSocketFDSN.java
@@ -40,7 +40,7 @@ public class SourceSocketFDSN extends SourceSocket {
           DataModule.getOrAddStation(station), network, location);
       interval = db.getInterval();
       int numberSamples = cachedData.length;
-      System.out.println("Expected sample count: " + numberSamples);
+      logger.debug("Expected sample count: " + numberSamples);
       ret.add(pdp);
       Segment segment = new Segment(this, 0,
           Date.from(Instant.ofEpochMilli(startTime)), (double) interval, numberSamples, 0);
@@ -53,10 +53,10 @@ public class SourceSocketFDSN extends SourceSocket {
 
   @Override
   public void load(Segment segment) {
-    System.out.println("SAMPLE COUNT: " + segment.getSampleCount());
+    logger.debug("SAMPLE COUNT: " + segment.getSampleCount());
     int cachedDataOffset = (int)
         ((segment.getStartTime().toInstant().toEpochMilli() - startTime) / interval);
-    System.out.println("CACHED DATA OFFSET? " + cachedDataOffset);
+    logger.debug("CACHED DATA OFFSET? " + cachedDataOffset);
     for (int i = 0; i < segment.getSampleCount(); ++i) {
       segment.addDataPoint((int) cachedData[i + cachedDataOffset]);
     }

--- a/src/main/java/com/isti/traceview/transformations/psd/TransPSD.java
+++ b/src/main/java/com/isti/traceview/transformations/psd/TransPSD.java
@@ -34,8 +34,6 @@ public class TransPSD implements ITransformation {
 
 	public static final String NAME = "Power spectra density";
 
-	private int effectiveLength = 0;
-
 	@Override
 	public void transform(List<PlotDataProvider> input, TimeInterval ti, IFilter filter, Object configuration,
 			JFrame parentFrame) {
@@ -51,7 +49,7 @@ public class TransPSD implements ITransformation {
 			try {
 				List<XYSeries> plotData = createData(input, filter, ti, parentFrame);
 				TimeInterval effectiveInterval = new TimeInterval(ti.getStart(),
-						ti.getStart() + new Double(input.get(0).getSampleRate() * effectiveLength).longValue());
+						ti.getStart() + ti.getEnd());
 				@SuppressWarnings("unused")
 				ViewPSD vp = new ViewPSD(parentFrame, plotData, effectiveInterval, (Configuration) configuration, input);
 			} catch (XMAXException e) {

--- a/src/main/java/com/isti/traceview/transformations/psd/TransPSD.java
+++ b/src/main/java/com/isti/traceview/transformations/psd/TransPSD.java
@@ -48,10 +48,8 @@ public class TransPSD implements ITransformation {
 		} else {
 			try {
 				List<XYSeries> plotData = createData(input, filter, ti, parentFrame);
-				TimeInterval effectiveInterval = new TimeInterval(ti.getStart(),
-						ti.getStart() + ti.getEnd());
 				@SuppressWarnings("unused")
-				ViewPSD vp = new ViewPSD(parentFrame, plotData, effectiveInterval, (Configuration) configuration, input);
+				ViewPSD vp = new ViewPSD(parentFrame, plotData, ti, (Configuration) configuration, input);
 			} catch (XMAXException e) {
 				logger.error(e);
 				if (!e.getMessage().equals("Operation cancelled")) {

--- a/src/main/java/com/isti/xmax/gui/XMAXframe.java
+++ b/src/main/java/com/isti/xmax/gui/XMAXframe.java
@@ -653,7 +653,7 @@ public class XMAXframe extends JFrame implements MouseInputListener, ActionListe
 	public void actionPerformed(ActionEvent e) {
 		JMenuItem source = (JMenuItem) (e.getSource());
 		Action action = actionMap.get(source.getText());
-		System.out.println("ACTION NAME: " + action.getValue(Action.NAME));
+		logger.debug("ACTION NAME: " + action.getValue(Action.NAME));
 		action.actionPerformed(new ActionEvent(this, 0, (String) action.getValue(Action.NAME)));
 
 		statusBar.setMessage("");


### PR DESCRIPTION
This used to derive duration from the effective length of the data (from the sample rate and number of samples). This has been replaced with a simple use of the end time parameter based on selection window, because length and sample rate are dependent on the traces coming in.

The old solution made sense when data had the same sample rate (and thus length) for a given time window. PSDs can now be done on a collection of data with arbitrary sample rates for each trace, so the effective time range is not consistent for all data.