### PR TITLE
DYO filter properly high/low passes data, fix filter reflections

### DIFF
--- a/src/main/java/com/isti/traceview/filters/FilterDYO.java
+++ b/src/main/java/com/isti/traceview/filters/FilterDYO.java
@@ -169,7 +169,9 @@ public class FilterDYO extends JDialog implements IFilter, PropertyChangeListene
 					cutHighFrequency = Double.NaN;
 				}
 				order = (Integer) orderCB.getSelectedItem();
-				if (!Double.isNaN(cutLowFrequency) && !Double.isNaN(cutHighFrequency)) {
+				if (!Double.isNaN(cutLowFrequency) && !Double.isNaN(cutHighFrequency) &&
+						cutLowFrequency > 0 && cutHighFrequency > 0) {
+					logger.info("Band pass filtering triggered");
 					if (cutLowFrequency < cutHighFrequency) {
 						filter = new FilterBP(order, cutLowFrequency, cutHighFrequency);
 						setVisible(false);
@@ -178,15 +180,18 @@ public class FilterDYO extends JDialog implements IFilter, PropertyChangeListene
 						JOptionPane.showMessageDialog(XMAXframe.getInstance(),
 								"Low frequency should be less then high one", "Error", JOptionPane.ERROR_MESSAGE);
 					}
-				} else if (!Double.isNaN(cutLowFrequency)) {
+				} else if (!Double.isNaN(cutLowFrequency) && cutLowFrequency > 0) {
+					logger.info("Low pass filtering triggered");
 					filter = new FilterLP(order, cutLowFrequency);
 					setVisible(false);
 					needProcessing = true;
-				} else if (!Double.isNaN(cutHighFrequency)) {
+				} else if (!Double.isNaN(cutHighFrequency) && cutHighFrequency > 0) {
+					logger.info("High pass filtering triggered");
 					filter = new FilterHP(order, cutHighFrequency);
 					setVisible(false);
 					needProcessing = true;
 				} else {
+					logger.warn("Could not get suitable filter parameters");
 					filter = null;
 					JOptionPane.showMessageDialog(XMAXframe.getInstance(),
 							"Please enter either low or high frequencies", "Error", JOptionPane.ERROR_MESSAGE);

--- a/src/main/java/com/isti/xmax/XMAX.java
+++ b/src/main/java/com/isti/xmax/XMAX.java
@@ -2,6 +2,11 @@ package com.isti.xmax;
 
 import com.isti.traceview.TraceView;
 import com.isti.traceview.common.TimeInterval;
+import com.isti.traceview.filters.AbstractFilter;
+import com.isti.traceview.filters.FilterBP;
+import com.isti.traceview.filters.FilterDYO;
+import com.isti.traceview.filters.FilterHP;
+import com.isti.traceview.filters.FilterLP;
 import com.isti.traceview.filters.IFilter;
 import com.isti.traceview.gui.ColorModeBySegment;
 import com.isti.traceview.transformations.ITransformation;
@@ -11,10 +16,11 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 import java.util.jar.Manifest;
-import javax.swing.JOptionPane;
 import javax.swing.SwingUtilities;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
@@ -176,7 +182,9 @@ public class XMAX extends TraceView {
 				} else {
 					// Find all classes that implement IFilter and ITransformation.
 					Reflections reflect = new Reflections("com.isti");
-					filters = reflect.getSubTypesOf(IFilter.class);
+					filters = new HashSet<>();
+					filters.addAll(reflect.getSubTypesOf(AbstractFilter.class));
+					filters.add(FilterDYO.class);
 					transformations = reflect.getSubTypesOf(ITransformation.class);
 
 					setDataModule(XMAXDataModule.getInstance());


### PR DESCRIPTION
Creating the abstract filter class broke reflections on the filter interface from which it is derived, causing the UI to fail to filter data properly and instead return an exception.